### PR TITLE
Unificación de reportes con relevamientos y campos del formulario

### DIFF
--- a/modules/datauy_cordoba/datauy_cordoba.module
+++ b/modules/datauy_cordoba/datauy_cordoba.module
@@ -191,12 +191,26 @@ function datauy_cordoba_form_reportes_node_form_alter(&$form, &$form_state) {
     }
     $form['parents'] = array('#type' => 'hidden', '#value' => $parents);
     $selected = isset($form_state['values']['cat']) ? $form_state['values']['cat'] : 0;
+    drupal_add_js('jQuery(document).ready(function () {
+      jQuery("#edit-cat").change(function(e){
+        e.preventDefault();
+        if (jQuery("#leaflet-widget_field-location-input").val() == "") {
+          alert("Por favor, primero seleccione una ubicación");
+        }
+      });
+    });', array(
+      'type' => 'inline',
+      'scope' => 'header',
+    //  'weight' => 5,
+    ));
+    $form['title']['#required'] = FALSE;
     $form['cat'] = array(
       '#type' => 'select',
       '#title' => t('Category'),
       '#required' => TRUE,
       '#weight' => -1,
       '#options' => $options,
+      '#default_value' => is_numeric($selected) ? $selected : '',
       '#ajax' => array(
         'callback' => 'ajax_subcat_dropdown_callback',
         'wrapper' => 'view-subcat-dropdown',
@@ -227,7 +241,9 @@ function datauy_cordoba_form_reportes_node_form_alter(&$form, &$form_state) {
     $form['#submit'][] = 'datauy_cordoba_report_submit';
   }
 }
+
 function datauy_cordoba_report_validate($form, &$form_state){
+  $form_state['values']['title'] = "Custom title";
   if (!$form_state['values']['subcat'])
     form_set_error('subcat', t('Por favor elija una Sub-categoría'));
 }
@@ -241,9 +257,12 @@ function datauy_cordoba_report_submit($form, &$form_state){
   //Limpiamos cats previas
   ksort($cat_tree);
   $form_state['values']['field_category']['und'] = array();
+  $title = "";
   foreach ($cat_tree as $key => $value) {
     $form_state['values']['field_category']['und'][$key]['tid'] = $value;
+    $title .= $terms_arr[$value]->name." ";
   }
+  $form_state['values']['title'] = $title;
 }
 // Ajax Call
 function ajax_subcat_dropdown_callback($form, $form_state) {
@@ -1561,10 +1580,11 @@ function datauy_cordoba_set_tree($tid, $depth, $vtree) {
   return $tree;
 }
 function datauy_cordoba_form_alter(&$form, &$form_state, $form_id ) {
-  $node = $form_state['node'];
+  if ( isset($form_state['node']) )
+    $node = $form_state['node'];
   if ( isset($form_state['field']['field_fotos']) && substr($form_id, 0, 7) != 'comment' ){
     //New node hide fotos
-    if ( !isset($node->nid) || !$node->nid ) {
+    if ( !isset($node) || !isset($node->nid) || !$node->nid ) {
       $form['field_fotos']['#access'] = 0;
     }
     $form['pud'] = array(
@@ -1592,7 +1612,7 @@ function datauy_cordoba_form_alter(&$form, &$form_state, $form_id ) {
     );
     $form['#submit'][] = 'datauy_cordoba_image_form_submit';
   }
-  if ( !in_array( $node->type, array('metas', 'objetivos', 'indicadores_municipales', 'capas_de_datos') ) && isset($form['field_cpc_de_pertenencia']) ){
+  if ( isset($node) && !in_array( $node->type, array('metas', 'objetivos', 'indicadores_municipales', 'capas_de_datos') ) && isset($form['field_cpc_de_pertenencia']) ){
     if ( !isset($node->nid) || !$node->nid ) {
       if ( isset($form['field_not_in_map']) ) {
         $form['field_not_in_map']['#access'] = 0;

--- a/themes/lmdmc/css/style.css
+++ b/themes/lmdmc/css/style.css
@@ -1417,9 +1417,10 @@ h2.comment-form {
   background-size:     cover;
   background-repeat:   no-repeat;
   background-position: center center;
-	position: relative;
-	top: -320px;
+	position: absolute;
+	top: 80px;
 	left: 9px;
+	cursor: pointer;
 }
 
 /**********
@@ -1955,4 +1956,18 @@ input#getcounts{
 
 .three-quarters-loader{
   margin: 0 auto 0 auto;
+}
+/** REPORTES **/
+.node-reportes-form .form-item-title {
+	display: none;
+}
+.node-reportes-form #edit-body-und-0-format {
+	display: none;
+}
+.plupload_scroll .plupload_filelist {
+	height: 56px;
+}
+#edit-pud_browse {
+	font-size: 20px;
+	margin-top: -8px;
 }

--- a/themes/lmdmc/js/lmdmc.js
+++ b/themes/lmdmc/js/lmdmc.js
@@ -75,7 +75,7 @@ function setDataUyLeafletCustoms(){
 function createMapAndSetEvents(idContainer, idLocationElement, nameLocationElement){
   $("#"+idContainer).empty();
   $("#"+idContainer).height(440);
-  $("#"+idContainer).append("<div id='pin_description'>Primero seleccione la ubicaciónen el mapa</div>");
+  $("#"+idContainer).append("<div id='pin_description'><p>Ubicar reporte:</p></div>");
   $("#"+idContainer).append("<div id='map_selector'></div>");
   $("#"+idContainer).append("<input id='"+idLocationElement+"' type='hidden' name='"+nameLocationElement+"' value=''>");
   $("#map_selector").height(400);
@@ -322,7 +322,8 @@ function createPinNodeSelectorAndSetEvents(map,type,idContainer,url, idNodeSelec
 
 function addGeolocateButton(map,idContainer){
   $("#"+idContainer).append("<div id='gps_control' class='control_over_map'></div>");
-  $('#gps_control').click(function() {
+  $('#gps_control').click(function(e) {
+    e.preventDefault();
     geolocate(map,true);
   });
 }

--- a/themes/lmdmc/templates/maintenance-page.tpl.php
+++ b/themes/lmdmc/templates/maintenance-page.tpl.php
@@ -74,7 +74,7 @@
  */
 ?>
 <div class="main_area column col-md-7">
-  <span>El 19/9 conocé</span><img src="/sites/ReportaCiudad/themes/lmdmc/logo.svg">
+  <img src="/sites/ReportaCiudad/themes/lmdmc/logo.svg"><span>Nos estamos actualizando... volvemos en un momento</span>
 </div>
 <style>
 @font-face {


### PR DESCRIPTION
Se corrigen errores varios. La carga de los relevamientos a tratar debe hacerse en la baseSe corrigen campos del formulario:  
* Se reflota botón de geoloclización en mapa  
* Botón de foto  
  - Lo que ocurre con el área de carga de las fotos es que es un widget que permite hacer el resize de la foto "on the fly" para su posterior subida. Ésto fue en su momento un requerimiento sobretodo por la carga de fotos desde las cámaras de los móviles.  
  - Se estudió el código, si bien la librería en la que se basa la adaptación a Drupal tiene la funcionalidad y hooks definidos para la interacción con sólo un botón, el módulo que lo integra con Drupal no, por lo que queda fuera del alcance.  
  - Como paliativo se achca espacio de visualización de archivos y se agranda la letra de link de carga  
* El resto de las funcionalidades estarían. 